### PR TITLE
Add syntax highlighting to diff view using Syntect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,6 +317,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,6 +1315,17 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "fastrand"
@@ -2517,6 +2552,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3139,6 +3180,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "onig"
+version = "6.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "open"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3607,6 +3670,7 @@ dependencies = [
  "tauri-plugin-store",
  "tauri-specta",
  "tokio",
+ "two-face",
 ]
 
 [[package]]
@@ -4989,6 +5053,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "onig",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 2.0.17",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5836,6 +5922,17 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "two-face"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b285c51f8a6ade109ed4566d33ac4fb289fb5d6cf87ed70908a5eaf65e948e34"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "syntect",
+]
 
 [[package]]
 name = "typeid"
@@ -6922,6 +7019,15 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,5 +42,6 @@ tauri-plugin-deep-link = "2"
 tauri-plugin-store = "2"
 rustls = {version = "0.23.36", default-features = false, features = ["ring", "std"] }
 obfstr = "0.4.4"
+two-face = { version = "0.5", features = ["syntect-default-fancy"] }
 [target."cfg(any(target_os = \"macos\", windows, target_os = \"linux\"))".dependencies]
 tauri-plugin-single-instance = { version = "2.0.0", features = ["deep-link"] }

--- a/src-tauri/src/models/pr.rs
+++ b/src-tauri/src/models/pr.rs
@@ -62,7 +62,16 @@ pub struct DiffLine {
     pub line_type: DiffLineType,
     pub old_lineno: Option<u32>,
     pub new_lineno: Option<u32>,
+    pub tokens: Vec<HighlightToken>,
+}
+
+#[derive(Clone, Debug, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct HighlightToken {
+    /// The text content of this token
     pub content: String,
+    /// CSS hex color (e.g., "#cf222e"), None for default foreground
+    pub color: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Type)]

--- a/src-tauri/src/services/highlight.rs
+++ b/src-tauri/src/services/highlight.rs
@@ -1,0 +1,115 @@
+use crate::models::HighlightToken;
+use two_face::re_exports::syntect::highlighting::{Color, Highlighter, Theme};
+use two_face::re_exports::syntect::parsing::{ParseState, ScopeStack, SyntaxReference, SyntaxSet};
+
+/// Pre-highlighted file content stored as a Vec for efficient O(1) line lookup.
+/// Index 0 = line 1, Index 1 = line 2, etc. (0-indexed storage, 1-indexed access)
+pub struct HighlightedFile {
+    lines: Vec<Vec<HighlightToken>>,
+}
+
+impl HighlightedFile {
+    /// Get tokens for a 1-indexed line number.
+    /// Returns None if line number is 0 or out of bounds.
+    pub fn get(&self, lineno: u32) -> Option<&Vec<HighlightToken>> {
+        if lineno == 0 {
+            return None;
+        }
+        self.lines.get((lineno - 1) as usize)
+    }
+
+    /// Returns an empty HighlightedFile (for binary files or missing blobs)
+    pub fn empty() -> Self {
+        Self { lines: Vec::new() }
+    }
+}
+
+pub struct HighlightService {
+    syntax_set: SyntaxSet,
+    theme: Theme,
+}
+
+impl HighlightService {
+    /// Creates a new HighlightService with default syntaxes and theme.
+    pub fn new() -> Self {
+        let syntax_set = two_face::syntax::extra_newlines();
+        let theme_set = two_face::theme::extra();
+
+        // Use a theme that works well on colored backgrounds
+        let theme = theme_set[two_face::theme::EmbeddedThemeName::Base16OceanDark].clone();
+
+        Self { syntax_set, theme }
+    }
+
+    /// Detects the syntax for a file path using Syntect's built-in detection.
+    /// Returns None if the language is not recognized.
+    fn detect_syntax(&self, file_path: &str) -> Option<&SyntaxReference> {
+        self.syntax_set
+            .find_syntax_for_file(file_path)
+            .unwrap_or(None)
+    }
+
+    /// Highlights the entire content of a file.
+    /// Returns a HighlightedFile with tokens indexed by line number.
+    ///
+    /// Parameters:
+    ///   - content: Full file content as a string
+    ///   - file_path: Path used for language detection
+    ///
+    /// Returns: HighlightedFile (Vec-based, 1-indexed access via .get())
+    pub fn highlight_file(&self, content: &str, file_path: &str) -> HighlightedFile {
+        let syntax = match self.detect_syntax(file_path) {
+            Some(s) => s,
+            None => {
+                // Unknown language: return plain tokens for each line
+                let lines = content.lines().map(Self::plain_tokens).collect();
+                return HighlightedFile { lines };
+            }
+        };
+
+        let highlighter = Highlighter::new(&self.theme);
+        let mut parse_state = ParseState::new(syntax);
+        let mut highlight_state = two_face::re_exports::syntect::highlighting::HighlightState::new(
+            &highlighter,
+            ScopeStack::new(),
+        );
+
+        let lines = content
+            .lines()
+            .map(|line| {
+                let ops = parse_state
+                    .parse_line(line, &self.syntax_set)
+                    .expect("Failed to parse line");
+                let styled = two_face::re_exports::syntect::highlighting::HighlightIterator::new(
+                    &mut highlight_state,
+                    &ops,
+                    line,
+                    &highlighter,
+                );
+
+                styled
+                    .map(|(style, text)| HighlightToken {
+                        content: text.to_string(),
+                        color: Some(color_to_hex(style.foreground)),
+                    })
+                    .collect()
+            })
+            .collect();
+
+        HighlightedFile { lines }
+    }
+
+    /// Creates plain (unhighlighted) tokens for a single line.
+    /// Used as fallback when language is unknown.
+    fn plain_tokens(line: &str) -> Vec<HighlightToken> {
+        vec![HighlightToken {
+            content: line.to_string(),
+            color: None,
+        }]
+    }
+}
+
+/// Converts syntect's Color to a CSS hex color string.
+fn color_to_hex(color: Color) -> String {
+    format!("#{:02x}{:02x}{:02x}", color.r, color.g, color.b)
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -2,10 +2,12 @@ mod auth;
 mod diff;
 mod git;
 mod github;
+mod highlight;
 mod review;
 
 pub use auth::*;
 pub use diff::*;
 pub use git::*;
 pub use github::*;
+pub use highlight::*;
 pub use review::*;

--- a/src/components/CommitDiffSection.tsx
+++ b/src/components/CommitDiffSection.tsx
@@ -247,7 +247,7 @@ function UnifiedDiffView({ hunks }: { hunks: DiffHunk[] }) {
 }
 
 function DiffLineComponent({ line }: { line: DiffLine }) {
-  const { bgColor, textColor } = getLineStyle(line.lineType)
+  const { bgColor } = getLineStyle(line.lineType)
 
   return (
     <div className={cn("flex hover:bg-muted/30", bgColor)}>
@@ -257,8 +257,12 @@ function DiffLineComponent({ line }: { line: DiffLine }) {
       <span className="w-12 text-right pr-2 text-muted-foreground select-none shrink-0">
         {line.newLineno || ""}
       </span>
-      <span className={cn("flex-1 pl-2 whitespace-pre", textColor)}>
-        {line.content}
+      <span className="flex-1 pl-2 whitespace-pre">
+        {line.tokens.map((token, idx) => (
+          <span key={idx} style={{ color: token.color ?? undefined }}>
+            {token.content}
+          </span>
+        ))}
       </span>
     </div>
   )
@@ -317,18 +321,15 @@ function getStatusStyle(status: FileChangeStatus): {
 
 function getLineStyle(lineType: DiffLineType): {
   bgColor: string
-  textColor: string
 } {
   switch (lineType) {
     case "addition":
       return {
         bgColor: "bg-green-50 dark:bg-green-950/30",
-        textColor: "text-green-700 dark:text-green-300",
       }
     case "deletion":
       return {
         bgColor: "bg-red-50 dark:bg-red-950/30",
-        textColor: "text-red-700 dark:text-red-300",
       }
     case "context":
     case "addeofnl":
@@ -336,7 +337,6 @@ function getLineStyle(lineType: DiffLineType): {
     default:
       return {
         bgColor: "bg-background",
-        textColor: "text-foreground",
       }
   }
 }


### PR DESCRIPTION
This commit implements comprehensive syntax highlighting for the diff viewer:

Backend Changes (Rust):
- Add syntect dependency with fancy-regex feature for pure Rust regex support
- Create HighlightService that highlights full file content to preserve multi-line syntax context
- Use base16-ocean.dark theme for GitHub-like appearance
- Add HighlightToken type with content and optional hex color
- Update DiffLine model to use Vec<HighlightToken> instead of raw string content
- Enhance DiffService to fetch full blob content and highlight before processing hunks
- Implement efficient Vec-based line lookup with 1-indexed access via .get() method
- Handle edge cases: unknown languages, binary files, missing blobs with graceful fallbacks

Frontend Changes (TypeScript/React):
- Update DiffLineComponent to render syntax tokens as individual <span> elements
- Remove textColor from getLineStyle - syntax highlighting now provides text colors
- Preserve existing green/red diff backgrounds while adding syntax colors on top
- Auto-generated TypeScript bindings include new HighlightToken and updated DiffLine types

Features:
- VS Code-accurate highlighting using TextMate grammars
- Language auto-detection from file extensions
- Support for 20+ languages: JS, TS, Rust, Go, Python, Java, HTML, CSS, JSON, etc.
- Performance optimized with single highlighter instance and efficient data structures
- Full file context ensures accurate highlighting of comments, strings, and multi-line constructs

The implementation follows the plan documented in .opencode/plans/syntax-highlighting-rust.md