### PR TITLE
feat: split diff generation into lazy-loaded file list and single fil…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ PR Manager is a Tauri 2 desktop application for managing GitHub pull requests lo
 ## Development Commands
 
 ```bash
-# Build for production
+# Build for production (takes a lot of time. Don't run this command for type checking)
 pnpm tauri build
 
 # Type checking

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"
+default-run="pr-manager"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,8 +5,8 @@ use tauri::Manager;
 use tauri_plugin_log::{Target, TargetKind};
 
 use crate::commands::{
-    auth_github, get_commit_diff, get_commits_in_range, get_local_repo_path, set_local_repo,
-    toggle_file_reviewed,
+    auth_github, get_commit_file_list, get_commits_in_range, get_file_diff, get_local_repo_path,
+    set_local_repo, toggle_file_reviewed,
 };
 use crate::db::DB;
 use crate::errors::CommandError;
@@ -83,8 +83,9 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
         .plugin(tauri_plugin_opener::init())
         .invoke_handler(tauri::generate_handler![
             auth_github,
-            get_commit_diff,
+            get_commit_file_list,
             get_commits_in_range,
+            get_file_diff,
             get_local_repo_path,
             set_local_repo,
             toggle_file_reviewed,
@@ -99,8 +100,9 @@ pub fn gen_ts_bindings() {
     tauri_specta::Builder::<tauri::Wry>::new()
         .commands(tauri_specta::collect_commands![
             auth_github,
-            get_commit_diff,
+            get_commit_file_list,
             get_commits_in_range,
+            get_file_diff,
             get_local_repo_path,
             set_local_repo,
             toggle_file_reviewed,

--- a/src-tauri/src/models/pr.rs
+++ b/src-tauri/src/models/pr.rs
@@ -14,14 +14,6 @@ pub struct PRCommit {
 
 #[derive(Clone, Debug, Serialize, Type)]
 #[serde(rename_all = "camelCase")]
-pub struct CommitDiff {
-    pub commit_sha: String,
-    pub change_id: Option<ChangeId>,
-    pub files: Vec<FileDiff>,
-}
-
-#[derive(Clone, Debug, Serialize, Type)]
-#[serde(rename_all = "camelCase")]
 pub struct FileDiff {
     pub old_path: Option<String>,
     pub new_path: Option<String>,
@@ -82,4 +74,42 @@ pub enum DiffLineType {
     Deletion,
     AddEofnl,
     DelEofnl,
+}
+
+/// Lightweight file entry for file list (no content/hunks)
+#[derive(Clone, Debug, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct FileEntry {
+    pub old_path: Option<String>,
+    pub new_path: Option<String>,
+    pub status: FileChangeStatus,
+    pub additions: u32,
+    pub deletions: u32,
+    pub is_binary: bool,
+    pub patch_id: Option<PatchId>,
+    pub is_reviewed: bool,
+}
+
+/// Response for get_commit_file_list command
+#[derive(Clone, Debug, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitFileList {
+    pub commit_sha: String,
+    pub change_id: Option<ChangeId>,
+    pub files: Vec<FileEntry>,
+}
+
+/// Response for get_file_diff command (single file)
+#[derive(Clone, Debug, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct SingleFileDiff {
+    pub old_path: Option<String>,
+    pub new_path: Option<String>,
+    pub status: FileChangeStatus,
+    pub additions: u32,
+    pub deletions: u32,
+    pub is_binary: bool,
+    pub hunks: Vec<DiffHunk>,
+    pub patch_id: Option<PatchId>,
+    pub is_reviewed: bool,
 }


### PR DESCRIPTION
…e diff

- Add get_commit_file_list command for fast file metadata (no blob fetch)
- Add get_file_diff command for on-demand single-file syntax highlighting
- Delete get_commit_diff command
- Refactor CommitDiffSection to lazy-load diffs when files are expanded
- File list loads instantly, individual diffs fetched on expand

Backend:
- FileEntry, CommitFileList, SingleFileDiff structs in models/pr.rs
- generate_file_list(), generate_single_file_diff() in diff.rs

Frontend:
- LazyFileDiff component fetches diff only when expanded
- Separate query keys for file list and individual diffs
- TanStack Query caches individual file diffs