### PR TITLE
Add jujutsu VCS installation hook for Claude sessions

### DIFF
--- a/.claude/hooks/install-jujutsu.sh
+++ b/.claude/hooks/install-jujutsu.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+if command -v jj &>/dev/null; then
+  echo "jujutsu is already installed: $(jj --version)"
+  exit 0
+fi
+
+echo "Installing jujutsu..."
+
+# Download pre-built binary (much faster than cargo install)
+JJ_VERSION="0.28.2"
+ARCHIVE="jj-v${JJ_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+URL="https://github.com/jj-vcs/jj/releases/download/v${JJ_VERSION}/${ARCHIVE}"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+curl -fsSL "$URL" -o "$TMPDIR/$ARCHIVE"
+tar -xzf "$TMPDIR/$ARCHIVE" -C "$TMPDIR"
+
+# Install to ~/.local/bin (usually on PATH in remote environments)
+mkdir -p "$HOME/.local/bin"
+mv "$TMPDIR/jj" "$HOME/.local/bin/jj"
+chmod +x "$HOME/.local/bin/jj"
+
+# Ensure ~/.local/bin is on PATH for the session
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$CLAUDE_ENV_FILE"
+fi
+
+echo "jujutsu installed: $("$HOME/.local/bin/jj" --version)"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/install-jujutsu.sh",
+            "timeout": 120,
+            "statusMessage": "Installing jujutsu..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
-.claude/
-
+.claude/settings.local.json
 
 node_modules/*
 src/bindings.ts


### PR DESCRIPTION
## Summary
This PR adds automatic installation of jujutsu (jj), a modern version control system, as part of the Claude session initialization process. It includes a setup hook and configuration file to enable seamless jujutsu availability in remote environments.

## Changes
- **Added `.claude/hooks/install-jujutsu.sh`**: Installation script that:
  - Checks if jujutsu is already installed to avoid redundant installations
  - Downloads a pre-built binary (v0.28.2) for faster setup compared to building from source
  - Installs to `~/.local/bin` for compatibility with remote environments
  - Automatically adds the installation directory to PATH via `CLAUDE_ENV_FILE`

- **Added `.claude/settings.json`**: Claude configuration file that:
  - Registers the jujutsu installation hook to run on session start
  - Sets a 120-second timeout for the installation process
  - Provides user feedback via status message

- **Modified `.gitignore`**: Removed `.claude/` from ignored paths to allow version control of Claude configuration files

## Implementation Details
- Uses `set -euo pipefail` for robust error handling in the bash script
- Downloads musl-based Linux binary for maximum compatibility across environments
- Implements cleanup via trap to remove temporary directories
- Gracefully handles cases where jujutsu is already installed

https://claude.ai/code/session_014NqR9TmLSvGzXR96vShWyq