### PR TITLE
fix: show empty diff for pure merge commits

### DIFF
--- a/src-tauri/src/services/word_diff.rs
+++ b/src-tauri/src/services/word_diff.rs
@@ -494,8 +494,10 @@ mod tests {
         let ins_keys: Vec<u32> = result.insertions.keys().copied().collect();
         // Must not have both (10↔21) and (11↔20) — that would be a crossing.
         assert!(
-            !(del_keys.contains(&10) && ins_keys.contains(&21)
-              && del_keys.contains(&11) && ins_keys.contains(&20)),
+            !(del_keys.contains(&10)
+                && ins_keys.contains(&21)
+                && del_keys.contains(&11)
+                && ins_keys.contains(&20)),
             "crossing pairs detected"
         );
     }


### PR DESCRIPTION
For merge commits, diff against parent(0) shows ALL changes from the merged branch. Pure merge commits (no conflict resolution) should produce an empty diff since all content was inherited from parents.

Compare each file's blob OID in the merge tree against other parent trees and skip files that match any parent, keeping only files with actual conflict resolutions or manual edits.