### PR TITLE
feat: align matched diff lines in split view

### DIFF
--- a/src/components/diff/DiffViews.tsx
+++ b/src/components/diff/DiffViews.tsx
@@ -55,54 +55,203 @@ type PairedLine = {
   right: DiffLine | null
 }
 
+type ProcessResult = {
+  pairs: PairedLine[]
+  nextIndex: number
+}
+
 function pairLinesForSplitView(lines: DiffLine[]): PairedLine[] {
-  const result: PairedLine[] = []
-  let i = 0
+  return processLines(lines, 0).pairs
+}
 
-  while (i < lines.length) {
-    const line = lines[i]
+function processLines(lines: DiffLine[], startIndex: number): ProcessResult {
+  if (startIndex >= lines.length) {
+    return { pairs: [], nextIndex: startIndex }
+  }
 
-    if (
-      line.lineType === "context" ||
-      line.lineType === "addeofnl" ||
-      line.lineType === "deleofnl"
-    ) {
-      // Context lines appear on both sides
-      result.push({ left: line, right: line })
-      i++
-    } else if (line.lineType === "deletion") {
-      // Collect consecutive deletions
-      const deletions: DiffLine[] = []
-      while (i < lines.length && lines[i].lineType === "deletion") {
-        deletions.push(lines[i])
-        i++
-      }
+  const line = lines[startIndex]
 
-      // Collect following consecutive additions
-      const additions: DiffLine[] = []
-      while (i < lines.length && lines[i].lineType === "addition") {
-        additions.push(lines[i])
-        i++
-      }
+  if (
+    line.lineType === "context" ||
+    line.lineType === "addeofnl" ||
+    line.lineType === "deleofnl"
+  ) {
+    const contextPair: PairedLine = { left: line, right: line }
+    const rest = processLines(lines, startIndex + 1)
+    return { pairs: [contextPair, ...rest.pairs], nextIndex: rest.nextIndex }
+  }
 
-      // Pair them up side-by-side
-      const maxLen = Math.max(deletions.length, additions.length)
-      for (let j = 0; j < maxLen; j++) {
-        result.push({
-          left: deletions[j] ?? null,
-          right: additions[j] ?? null,
-        })
-      }
-    } else if (line.lineType === "addition") {
-      // Standalone addition (no preceding deletion)
-      result.push({ left: null, right: line })
-      i++
-    } else {
-      i++
+  if (line.lineType === "deletion") {
+    const deletionsResult = collectDeletions(lines, startIndex)
+    const additionsResult = collectAdditions(lines, deletionsResult.nextIndex)
+    const alignedPairs = alignChangedBlock(
+      deletionsResult.lines,
+      additionsResult.lines,
+    )
+    const rest = processLines(lines, additionsResult.nextIndex)
+    return {
+      pairs: [...alignedPairs, ...rest.pairs],
+      nextIndex: rest.nextIndex,
     }
   }
 
-  return result
+  if (line.lineType === "addition") {
+    const additionPair: PairedLine = { left: null, right: line }
+    const rest = processLines(lines, startIndex + 1)
+    return { pairs: [additionPair, ...rest.pairs], nextIndex: rest.nextIndex }
+  }
+
+  // Skip unhandled line types
+  return processLines(lines, startIndex + 1)
+}
+
+function collectDeletions(
+  lines: DiffLine[],
+  startIndex: number,
+): { lines: DiffLine[]; nextIndex: number } {
+  const endIndex = lines
+    .slice(startIndex)
+    .findIndex((line) => line.lineType !== "deletion")
+
+  const actualEndIndex = endIndex === -1 ? lines.length : startIndex + endIndex
+
+  return {
+    lines: lines.slice(startIndex, actualEndIndex),
+    nextIndex: actualEndIndex,
+  }
+}
+
+function collectAdditions(
+  lines: DiffLine[],
+  startIndex: number,
+): { lines: DiffLine[]; nextIndex: number } {
+  const endIndex = lines
+    .slice(startIndex)
+    .findIndex((line) => line.lineType !== "addition")
+
+  const actualEndIndex = endIndex === -1 ? lines.length : startIndex + endIndex
+
+  return {
+    lines: lines.slice(startIndex, actualEndIndex),
+    nextIndex: actualEndIndex,
+  }
+}
+
+/** Align a block of consecutive deletions + additions using backend match info. */
+function alignChangedBlock(
+  deletions: DiffLine[],
+  additions: DiffLine[],
+): PairedLine[] {
+  const addByNewLineno = buildAdditionMap(additions)
+  const matchPairs = findMatchPairs(deletions, addByNewLineno)
+
+  if (matchPairs.length === 0) {
+    return positionalPairing(deletions, additions)
+  }
+
+  return alignWithMatchPairs(deletions, additions, matchPairs)
+}
+
+function buildAdditionMap(additions: DiffLine[]): Map<number, number> {
+  return additions.reduce((map, addition, idx) => {
+    if (addition.newLineno != null) {
+      map.set(addition.newLineno, idx)
+    }
+    return map
+  }, new Map<number, number>())
+}
+
+function findMatchPairs(
+  deletions: DiffLine[],
+  addByNewLineno: Map<number, number>,
+): [number, number][] {
+  return deletions.reduce<[number, number][]>((pairs, deletion, delIdx) => {
+    if (deletion.newLineno != null) {
+      const addIdx = addByNewLineno.get(deletion.newLineno)
+      if (addIdx != null) {
+        return [...pairs, [delIdx, addIdx]]
+      }
+    }
+    return pairs
+  }, [])
+}
+
+function positionalPairing(
+  deletions: DiffLine[],
+  additions: DiffLine[],
+): PairedLine[] {
+  const maxLen = Math.max(deletions.length, additions.length)
+  return Array.from({ length: maxLen }, (_, j) => ({
+    left: deletions[j] ?? null,
+    right: additions[j] ?? null,
+  }))
+}
+
+function alignWithMatchPairs(
+  deletions: DiffLine[],
+  additions: DiffLine[],
+  matchPairs: [number, number][],
+): PairedLine[] {
+  type AlignState = {
+    pairs: PairedLine[]
+    delPtr: number
+    addPtr: number
+  }
+
+  const finalState = matchPairs.reduce<AlignState>(
+    (state, [delIdx, addIdx]) => {
+      // Emit unmatched deletions before this pair
+      const unmatchedDels = createRange(state.delPtr, delIdx).map((i) => ({
+        left: deletions[i],
+        right: null,
+      }))
+
+      // Emit unmatched additions before this pair
+      const unmatchedAdds = createRange(state.addPtr, addIdx).map((i) => ({
+        left: null,
+        right: additions[i],
+      }))
+
+      // Emit the matched pair
+      const matchedPair: PairedLine = {
+        left: deletions[delIdx],
+        right: additions[addIdx],
+      }
+
+      return {
+        pairs: [
+          ...state.pairs,
+          ...unmatchedDels,
+          ...unmatchedAdds,
+          matchedPair,
+        ],
+        delPtr: delIdx + 1,
+        addPtr: addIdx + 1,
+      }
+    },
+    { pairs: [], delPtr: 0, addPtr: 0 },
+  )
+
+  // Remaining unmatched lines after all pairs
+  const remainingDels = createRange(finalState.delPtr, deletions.length).map(
+    (i) => ({
+      left: deletions[i],
+      right: null,
+    }),
+  )
+
+  const remainingAdds = createRange(finalState.addPtr, additions.length).map(
+    (i) => ({
+      left: null,
+      right: additions[i],
+    }),
+  )
+
+  return [...finalState.pairs, ...remainingDels, ...remainingAdds]
+}
+
+function createRange(start: number, end: number): number[] {
+  return Array.from({ length: Math.max(0, end - start) }, (_, i) => start + i)
 }
 
 function SplitLineRow({ pair }: { pair: PairedLine }) {

--- a/src/components/diff/FileDiffItem.tsx
+++ b/src/components/diff/FileDiffItem.tsx
@@ -1,6 +1,6 @@
 import * as Collapsible from "@radix-ui/react-collapsible"
 import { useQueryClient } from "@tanstack/react-query"
-import { ChevronDown, ChevronRight, Check, Copy } from "lucide-react"
+import { Check, ChevronDown, ChevronRight, Copy } from "lucide-react"
 import { useCallback, useState } from "react"
 import { useHotkeys } from "react-hotkeys-hook"
 


### PR DESCRIPTION
Propagate line pairing info from the backend's similarity-based matching
to the frontend so the split diff view can align paired lines on the
same row instead of using naive positional pairing.

Backend: add pair_lineno field to DiffLine and populate it from the
word_diff matching pairs (old_lineno → new_lineno for deletions,
new_lineno → old_lineno for additions).

Frontend: replace positional zip in pairLinesForSplitView with an
alignment algorithm that uses pairLineno as sync anchors, inserting
blank padding rows for unmatched lines.