### PR TITLE
feat: integrate real GitHub data for PR reviewers and checks

### DIFF
--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -8,6 +8,10 @@ export const queryKeys = {
     ["pullRequests", owner, repo] as const,
   pullRequest: (owner: string, repo: string, pullNumber: number) =>
     ["pullRequest", owner, repo, pullNumber] as const,
+  pullRequestReviews: (owner: string, repo: string, pullNumber: number) =>
+    ["pullRequestReviews", owner, repo, pullNumber] as const,
+  pullRequestChecks: (owner: string, repo: string, ref: string) =>
+    ["pullRequestChecks", owner, repo, ref] as const,
   pullRequestCommits: (
     localDir: string | null,
     baseSha: string | undefined,

--- a/src/routes/pulls.$owner.$repo.$number/-OverviewTab.tsx
+++ b/src/routes/pulls.$owner.$repo.$number/-OverviewTab.tsx
@@ -10,6 +10,7 @@ import { PRComments } from "./-PRComments"
 import { PRReviewers } from "./-PRReviewers"
 import { useMergePullRequest } from "./-useMergePullRequest"
 import { usePullRequest } from "./-usePullRequest"
+import { usePullRequestDetails } from "./-usePullRequestDetails"
 
 type OverviewTabProps = {
   localDir: string | null
@@ -33,6 +34,7 @@ export function OverviewTab({
     repo,
     number,
   )
+  const { data: prDetails } = usePullRequestDetails(owner, repo, number)
 
   const mergeMutation = useMergePullRequest()
 
@@ -115,7 +117,11 @@ export function OverviewTab({
             {/* CI Checks + Merge Actions */}
             <div className="rounded-lg border bg-card">
               <div className="p-4 space-y-4">
-                <PRChecks />
+                <PRChecks
+                  owner={owner}
+                  repo={repo}
+                  headSha={prDetails?.head.sha}
+                />
                 {isAuthenticated && pullRequest && pullRequest.mergeable && (
                   <div className="pt-4 border-t flex justify-end">
                     <Button
@@ -135,7 +141,7 @@ export function OverviewTab({
 
           {/* Right sidebar */}
           <div className="w-80 shrink-0">
-            <PRReviewers />
+            <PRReviewers owner={owner} repo={repo} number={number} />
           </div>
         </div>
       </div>

--- a/src/routes/pulls.$owner.$repo.$number/-PRReviewers.tsx
+++ b/src/routes/pulls.$owner.$repo.$number/-PRReviewers.tsx
@@ -1,56 +1,80 @@
 import { CheckCircle, Clock, MessageSquare } from "lucide-react"
 
+import { type Reviewer, usePullRequestReviews } from "./-usePullRequestReviews"
+
 type ReviewStatus = "approved" | "changes_requested" | "pending" | "commented"
 
-type MockReviewer = {
-  username: string
-  avatarInitials: string
-  status: ReviewStatus
+type PRReviewersProps = {
+  owner: string
+  repo: string
+  number: number
 }
 
-const MOCK_REVIEWERS: MockReviewer[] = [
-  {
-    username: "john-doe",
-    avatarInitials: "JD",
-    status: "approved",
-  },
-  {
-    username: "alice-smith",
-    avatarInitials: "AS",
-    status: "changes_requested",
-  },
-  {
-    username: "bob-jones",
-    avatarInitials: "BJ",
-    status: "pending",
-  },
-]
+function getUserInitials(username: string): string {
+  return username
+    .split(/[-_]/)
+    .map((part) => part[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2)
+}
 
-export function PRReviewers() {
+export function PRReviewers({ owner, repo, number }: PRReviewersProps) {
+  const {
+    data: reviewers,
+    isLoading,
+    error,
+  } = usePullRequestReviews(owner, repo, number)
+
   return (
     <div className="rounded-lg border bg-card">
       <div className="p-4 border-b">
         <h3 className="text-sm font-medium">
-          Reviewers ({MOCK_REVIEWERS.length})
+          Reviewers {reviewers && `(${reviewers.length})`}
         </h3>
       </div>
       <div className="p-4 space-y-3">
-        {MOCK_REVIEWERS.map((reviewer) => (
-          <ReviewerItem key={reviewer.username} reviewer={reviewer} />
-        ))}
+        {isLoading && (
+          <div className="text-sm text-muted-foreground">
+            Loading reviewers...
+          </div>
+        )}
+        {error && (
+          <div className="text-sm text-red-600 dark:text-red-400">
+            Failed to load reviewers
+          </div>
+        )}
+        {reviewers && reviewers.length === 0 && (
+          <div className="text-sm text-muted-foreground">
+            No reviewers assigned
+          </div>
+        )}
+        {reviewers &&
+          reviewers.length > 0 &&
+          reviewers.map((reviewer) => (
+            <ReviewerItem key={reviewer.username} reviewer={reviewer} />
+          ))}
       </div>
     </div>
   )
 }
 
-function ReviewerItem({ reviewer }: { reviewer: MockReviewer }) {
+function ReviewerItem({ reviewer }: { reviewer: Reviewer }) {
   const { icon: Icon, color, label } = getReviewStatusInfo(reviewer.status)
 
   return (
     <div className="flex items-center gap-3">
-      <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center text-xs font-medium shrink-0">
-        {reviewer.avatarInitials}
-      </div>
+      {reviewer.avatarUrl ? (
+        <img
+          src={reviewer.avatarUrl}
+          alt={reviewer.username}
+          className="w-8 h-8 rounded-full shrink-0"
+        />
+      ) : (
+        <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center text-xs font-medium shrink-0">
+          {getUserInitials(reviewer.username)}
+        </div>
+      )}
       <div className="flex-1 min-w-0">
         <div className="text-sm font-medium">{reviewer.username}</div>
         <div className={`text-xs flex items-center gap-1 ${color}`}>

--- a/src/routes/pulls.$owner.$repo.$number/-usePullRequestChecks.ts
+++ b/src/routes/pulls.$owner.$repo.$number/-usePullRequestChecks.ts
@@ -1,0 +1,145 @@
+import { RestEndpointMethodTypes } from "@octokit/rest"
+import { useQuery } from "@tanstack/react-query"
+
+import { useGithub } from "@/context/GithubContext"
+import { queryKeys } from "@/lib/queryKeys"
+
+type CheckStatus = "success" | "failure" | "pending" | "cancelled"
+
+export type Check = {
+  name: string
+  context: string
+  status: CheckStatus
+  duration?: string
+  detailsUrl?: string
+  appIconUrl?: string
+  appName?: string
+}
+
+type GitHubCheckRun =
+  RestEndpointMethodTypes["checks"]["listForRef"]["response"]["data"]["check_runs"][number]
+
+function mapGitHubCheckToStatus(check: GitHubCheckRun): CheckStatus {
+  if (check.status === "queued" || check.status === "in_progress") {
+    return "pending"
+  }
+
+  switch (check.conclusion) {
+    case "success":
+    case "neutral":
+      return "success"
+    case "failure":
+    case "timed_out":
+    case "action_required":
+      return "failure"
+    case "cancelled":
+    case "skipped":
+      return "cancelled"
+    default:
+      return "pending"
+  }
+}
+
+function calculateDuration(
+  startedAt?: string | null,
+  completedAt?: string | null,
+): string | undefined {
+  if (!startedAt || !completedAt) return undefined
+
+  const start = new Date(startedAt).getTime()
+  const end = new Date(completedAt).getTime()
+  const durationMs = end - start
+
+  const seconds = Math.floor(durationMs / 1000)
+  const minutes = Math.floor(seconds / 60)
+  const hours = Math.floor(minutes / 60)
+
+  if (hours > 0) {
+    const remainingMinutes = minutes % 60
+    return `${hours}h ${remainingMinutes}m`
+  } else if (minutes > 0) {
+    const remainingSeconds = seconds % 60
+    return `${minutes}m ${remainingSeconds}s`
+  } else {
+    return `${seconds}s`
+  }
+}
+
+function isCICDCheck(check: GitHubCheckRun): boolean {
+  const checkName = check.name.toLowerCase()
+
+  const cicdPatterns = [
+    "test",
+    "lint",
+    "build",
+    "typecheck",
+    "type-check",
+    "format",
+    "cargo",
+    "npm",
+    "pnpm",
+    "yarn",
+    "compile",
+    "validate",
+    "check",
+    "ci",
+    "verify",
+  ]
+
+  const excludedPatterns = [
+    "codeql",
+    "security",
+    "dependency",
+    "dependabot",
+    "cleanup",
+    "upload",
+    "download",
+    "cache",
+    "artifact",
+    "setup",
+    "prepare",
+    "agent",
+    "autovalidate",
+  ]
+
+  if (excludedPatterns.some((pattern) => checkName.includes(pattern))) {
+    return false
+  }
+
+  return cicdPatterns.some((pattern) => checkName.includes(pattern))
+}
+
+export function usePullRequestChecks(
+  owner: string,
+  repo: string,
+  headSha: string | undefined,
+) {
+  const { isAuthenticated, octokit } = useGithub()
+
+  return useQuery({
+    queryKey: queryKeys.pullRequestChecks(owner, repo, headSha || ""),
+    queryFn: async (): Promise<Check[]> => {
+      if (!headSha) return []
+
+      const { data } = await octokit!.checks.listForRef({
+        owner,
+        repo,
+        ref: headSha,
+      })
+
+      const cicdChecks = data.check_runs.filter(isCICDCheck)
+
+      return cicdChecks.map((check) => ({
+        name: check.name,
+        context: check.name,
+        status: mapGitHubCheckToStatus(check),
+        duration: calculateDuration(check.started_at, check.completed_at),
+        detailsUrl: check.html_url ?? undefined,
+        appIconUrl: check.app?.owner?.avatar_url ?? undefined,
+        appName: check.app?.name ?? undefined,
+      }))
+    },
+    enabled: !!octokit && isAuthenticated && !!headSha,
+    refetchInterval: 60 * 1000,
+  })
+}

--- a/src/routes/pulls.$owner.$repo.$number/-usePullRequestReviews.ts
+++ b/src/routes/pulls.$owner.$repo.$number/-usePullRequestReviews.ts
@@ -1,0 +1,109 @@
+import { RestEndpointMethodTypes } from "@octokit/rest"
+import { useQuery } from "@tanstack/react-query"
+
+import { useGithub } from "@/context/GithubContext"
+import { queryKeys } from "@/lib/queryKeys"
+
+type ReviewStatus = "approved" | "changes_requested" | "pending" | "commented"
+
+export type Reviewer = {
+  username: string
+  avatarUrl?: string
+  status: ReviewStatus
+}
+
+type GitHubReview =
+  RestEndpointMethodTypes["pulls"]["listReviews"]["response"]["data"][number]
+
+function mapGitHubStateToStatus(state: string): ReviewStatus {
+  switch (state) {
+    case "APPROVED":
+      return "approved"
+    case "CHANGES_REQUESTED":
+      return "changes_requested"
+    case "COMMENTED":
+      return "commented"
+    case "DISMISSED":
+      return "commented"
+    case "PENDING":
+      return "pending"
+    default:
+      return "commented"
+  }
+}
+
+export function usePullRequestReviews(
+  owner: string,
+  repo: string,
+  pullNumber: number,
+) {
+  const { isAuthenticated, octokit } = useGithub()
+
+  return useQuery({
+    queryKey: queryKeys.pullRequestReviews(owner, repo, pullNumber),
+    queryFn: async (): Promise<Reviewer[]> => {
+      const [{ data: reviews }, { data: pullRequest }] = await Promise.all([
+        octokit!.pulls.listReviews({
+          owner,
+          repo,
+          pull_number: pullNumber,
+        }),
+        octokit!.pulls.get({
+          owner,
+          repo,
+          pull_number: pullNumber,
+        }),
+      ])
+
+      const reviewsByUser = new Map<string, GitHubReview>()
+
+      const sortedReviews = [...reviews].sort((a, b) => {
+        if (!a.submitted_at || !b.submitted_at) return 0
+        return (
+          new Date(b.submitted_at).getTime() -
+          new Date(a.submitted_at).getTime()
+        )
+      })
+
+      for (const review of sortedReviews) {
+        if (!review.user?.login) continue
+
+        const username = review.user.login
+        if (!reviewsByUser.has(username)) {
+          if (review.state !== "DISMISSED") {
+            reviewsByUser.set(username, review)
+          } else if (
+            !sortedReviews.some(
+              (r) => r.user?.login === username && r.state !== "DISMISSED",
+            )
+          ) {
+            reviewsByUser.set(username, review)
+          }
+        }
+      }
+
+      const reviewers: Reviewer[] = Array.from(reviewsByUser.values()).map(
+        (review) => ({
+          username: review.user!.login,
+          avatarUrl: review.user!.avatar_url,
+          status: mapGitHubStateToStatus(review.state),
+        }),
+      )
+
+      if (pullRequest.requested_reviewers) {
+        for (const requested of pullRequest.requested_reviewers) {
+          if (!reviewsByUser.has(requested.login)) {
+            reviewers.push({
+              username: requested.login,
+              avatarUrl: requested.avatar_url,
+              status: "pending",
+            })
+          }
+        }
+      }
+
+      return reviewers
+    },
+    enabled: !!octokit && isAuthenticated,
+  })
+}


### PR DESCRIPTION
- Add usePullRequestReviews hook to fetch review data from GitHub API
  - Combines actual reviews with requested reviewers
  - Maps GitHub review states to app ReviewStatus type
  - Handles multiple reviews from same user

- Add usePullRequestChecks hook to fetch CI/CD check runs
  - Filters to show only CI/CD checks (excludes CodeQL, security scans, etc.)
  - Maps GitHub check statuses to app CheckStatus type
  - Calculates duration and provides check detail URLs
  - Displays app icons for each check

- Update PRReviewers component
  - Replace mock data with real API integration
  - Display GitHub avatar images
  - Show loading, error, and empty states

- Update PRChecks component  
  - Replace mock data with real API integration
  - Add circular progress ring showing check status distribution
  - Make UI more compact with reduced spacing
  - Make check names clickable links to details
  - Increase header size for better prominence

- Wire up components in OverviewTab with required props