### PR TITLE
feat: use jj CLI for get_commits_in_range to always populate change_id

### DIFF
--- a/src-tauri/src/commands/pr.rs
+++ b/src-tauri/src/commands/pr.rs
@@ -3,7 +3,7 @@ use tauri::command;
 use super::Result;
 use crate::db::{RepoDb, ReviewedFileRepository};
 use crate::models::{ChangeId, CommitFileList, DiffHunk, PatchId};
-use crate::services::{diff, git};
+use crate::services::{diff, git, jj};
 
 #[command]
 #[specta::specta]
@@ -12,12 +12,7 @@ pub async fn get_commits_in_range(
     base_sha: String,
     head_sha: String,
 ) -> Result<Vec<crate::models::PRCommit>> {
-    let repository = git::open_repository(&local_dir)?;
-    Ok(git::get_commits_in_range(
-        &repository,
-        &base_sha,
-        &head_sha,
-    )?)
+    Ok(jj::get_commits_in_range(&local_dir, &base_sha, &head_sha)?)
 }
 
 #[command]

--- a/src-tauri/src/models/pr.rs
+++ b/src-tauri/src/models/pr.rs
@@ -6,7 +6,7 @@ use super::{ChangeId, PatchId};
 #[derive(Clone, Debug, Serialize, Type)]
 #[serde(rename_all = "camelCase")]
 pub struct PRCommit {
-    pub change_id: Option<ChangeId>,
+    pub change_id: ChangeId,
     pub sha: String,
     pub summary: String,
     pub description: String,

--- a/src-tauri/src/services/git.rs
+++ b/src-tauri/src/services/git.rs
@@ -1,6 +1,6 @@
-use git2::{Commit, Oid, Repository};
+use git2::{Commit, Repository};
 
-use crate::models::{ChangeId, PRCommit};
+use crate::models::ChangeId;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -28,39 +28,4 @@ pub fn get_change_id(commit: &Commit<'_>) -> Option<ChangeId> {
         .header_field_bytes("change-id")
         .ok()
         .and_then(|buf| buf.as_str().map(String::from).map(ChangeId::from))
-}
-
-pub fn get_commits_in_range(
-    repo: &Repository,
-    base_sha: &str,
-    head_sha: &str,
-) -> Result<Vec<PRCommit>> {
-    let head_oid = Oid::from_str(head_sha).map_err(|_| Error::InvalidSha(head_sha.to_string()))?;
-
-    let base_oid = Oid::from_str(base_sha).map_err(|_| Error::InvalidSha(base_sha.to_string()))?;
-
-    let mut walker = repo.revwalk()?;
-
-    let range = format!("{}..{}", base_oid, head_oid);
-    walker.push_range(&range)?;
-
-    let mut commits = Vec::new();
-    for oid in walker {
-        let oid = oid?;
-        let commit = repo
-            .find_commit(oid)
-            .map_err(|_| Error::CommitNotFound(oid.to_string()))?;
-
-        let change_id = get_change_id(&commit);
-
-        let pr_commit = PRCommit {
-            change_id,
-            sha: oid.to_string(),
-            summary: commit.summary().unwrap_or("").to_string(),
-            description: commit.body().unwrap_or("").to_string(),
-        };
-        commits.push(pr_commit);
-    }
-
-    Ok(commits)
 }

--- a/src/routes/pulls.$owner.$repo.$number/-components/FilesTab.tsx
+++ b/src/routes/pulls.$owner.$repo.$number/-components/FilesTab.tsx
@@ -193,12 +193,10 @@ function CommitDetail({ commit }: { commit: PRCommit }) {
             {commit.sha.slice(0, 12)}
           </code>
         </p>
-        {commit.changeId && (
-          <p>
-            <span className="font-medium">Change ID:</span>{" "}
-            <code className="bg-muted px-1 rounded">{commit.changeId}</code>
-          </p>
-        )}
+        <p>
+          <span className="font-medium">Change ID:</span>{" "}
+          <code className="bg-muted px-1 rounded">{commit.changeId}</code>
+        </p>
       </div>
     </div>
   )

--- a/src/routes/pulls.$owner.$repo.$number/-hooks/usePullRequest.ts
+++ b/src/routes/pulls.$owner.$repo.$number/-hooks/usePullRequest.ts
@@ -5,7 +5,7 @@ import { queryKeys } from "@/lib/queryKeys"
 import { usePullRequestDetails } from "../-hooks/usePullRequestDetails"
 
 export interface PRCommit {
-  changeId: string | null
+  changeId: string
   sha: string
   summary: string
   description: string


### PR DESCRIPTION
Replace the libgit2-based get_commits_in_range with jj CLI, ensuring
change_id is always available. Make PRCommit.change_id non-optional.
Add unit tests for the jj output parser.