### PR TITLE
Switch GitHub auth from OAuth to Device Flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,6 @@ jobs:
 
       - run: cargo fmt --check --manifest-path src-tauri/Cargo.toml
       - run: cargo test --workspace
-        env:
-          GH_APP_CLIENT_SECRET: ${{ secrets.GH_APP_CLIENT_SECRET }}
 
   typecheck:
     name: Typecheck
@@ -81,6 +79,4 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm gen
-        env:
-          GH_APP_CLIENT_SECRET: ${{ secrets.GH_APP_CLIENT_SECRET }}
       - run: pnpm check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,26 +693,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "const-random"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
-dependencies = [
- "const-random-macro",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
-dependencies = [
- "getrandom 0.2.16",
- "once_cell",
- "tiny-keccak",
-]
-
-[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,6 +706,16 @@ checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "time",
  "version_check",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -751,9 +741,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.10.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -764,7 +754,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.10.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -800,12 +790,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -1078,21 +1062,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dlv-list"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
-dependencies = [
- "const-random",
-]
-
-[[package]]
-name = "dotenvy"
-version = "0.15.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
-
-[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1218,6 +1187,15 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "endi"
@@ -1401,12 +1379,21 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1419,6 +1406,12 @@ dependencies = [
  "quote",
  "syn 2.0.111",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1703,11 +1696,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1752,7 +1743,7 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "url",
 ]
@@ -1882,6 +1873,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.12.1",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -2020,6 +2030,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -2047,7 +2058,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2060,6 +2070,22 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -2082,9 +2108,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2588,12 +2616,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2691,6 +2713,23 @@ dependencies = [
  "serde",
  "thiserror 2.0.17",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5d26952a508f321b4d3d2e80e78fc2603eaefcdf0c30783867f19586518bdc"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe 0.2.1",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2840,32 +2879,6 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "oauth2"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "getrandom 0.2.16",
- "http",
- "rand 0.8.5",
- "reqwest",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "sha2",
- "thiserror 1.0.69",
- "url",
-]
-
-[[package]]
-name = "obfstr"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d354e9a302760d07e025701d40534f17dd1fe4c4db955b4e3bd2907c63bdee"
 
 [[package]]
 name = "objc-sys"
@@ -3214,10 +3227,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
@@ -3236,16 +3281,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "ordered-multimap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
-dependencies = [
- "dlv-list",
- "hashbrown 0.14.5",
-]
 
 [[package]]
 name = "ordered-stream"
@@ -3762,61 +3797,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.17",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
-dependencies = [
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand 0.9.2",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.17",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4050,27 +4030,30 @@ checksum = "b6eff9328d40131d43bd911d42d79eb6a47312002a4daefc9e37f17e74a7701a"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-native-tls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4080,7 +4063,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -4089,15 +4071,12 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
- "dotenvy",
  "git2",
  "log",
- "oauth2",
- "obfstr",
  "octocrab",
+ "reqwest",
  "rusqlite",
  "rusqlite-from-row",
- "rustls",
  "serde",
  "serde_json",
  "sha1",
@@ -4106,7 +4085,6 @@ dependencies = [
  "specta-typescript",
  "tauri",
  "tauri-build",
- "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-log",
  "tauri-plugin-opener",
@@ -4253,16 +4231,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-ini"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
-dependencies = [
- "cfg-if",
- "ordered-multimap",
-]
-
-[[package]]
 name = "rust_decimal"
 version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4277,12 +4245,6 @@ dependencies = [
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -4327,7 +4289,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -4339,7 +4301,6 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -4483,7 +4444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
  "bitflags 2.10.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4849,7 +4810,7 @@ dependencies = [
  "bytemuck",
  "cfg_aliases",
  "core-graphics",
- "foreign-types",
+ "foreign-types 0.5.0",
  "js-sys",
  "log",
  "objc2 0.5.2",
@@ -5084,6 +5045,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5104,7 +5086,7 @@ checksum = "f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7"
 dependencies = [
  "bitflags 2.10.0",
  "block2 0.6.2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch",
@@ -5292,27 +5274,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tauri-plugin-deep-link"
-version = "2.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444b091f24f2f6bdb4a305b54d3961f629c11861c685aceeea9a1972f89e43d5"
-dependencies = [
- "dunce",
- "plist",
- "rust-ini",
- "serde",
- "serde_json",
- "tauri",
- "tauri-plugin",
- "tauri-utils",
- "thiserror 2.0.17",
- "tracing",
- "url",
- "windows-registry",
- "windows-result 0.3.4",
-]
-
-[[package]]
 name = "tauri-plugin-dialog"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5405,7 +5366,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri",
- "tauri-plugin-deep-link",
  "thiserror 2.0.17",
  "tracing",
  "windows-sys 0.60.2",
@@ -5643,15 +5603,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5703,6 +5654,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -6357,15 +6318,6 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/cspell.json
+++ b/cspell.json
@@ -7,23 +7,17 @@
     "specta",
     "Failable",
     "Newtype",
-    "dotenvy",
     "rustc",
-    "dotenv",
     "staticlib",
     "serde",
     "octocrab",
     "chrono",
-    "rustls",
-    "obfstr",
     "thiserror",
     "cdylib",
     "rlib",
     "Jujutu",
     "Eofnl",
     "Typechange",
-    "pkce",
-    "obfstring",
     "reqwest"
   ]
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,7 +16,6 @@ name = "revue_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
-dotenvy = "0.15.7"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
@@ -38,11 +37,8 @@ specta-typescript = "0.0.9"
 dirs = "5.0"
 sha1 = "0.10"
 chrono = "0.4"
-oauth2 = {version = "5.0.0", features = ["timing-resistant-secret-traits"] }
-tauri-plugin-deep-link = "2"
+reqwest = { version = "0.12", features = ["json"] }
 tauri-plugin-store = "2"
-rustls = {version = "0.23.36", default-features = false, features = ["ring", "std"] }
-obfstr = "0.4.4"
 two-face = { version = "0.5", features = ["syntect-default-fancy"] }
 thiserror = "2"
 similar = "2"
@@ -50,4 +46,4 @@ similar = "2"
 [dev-dependencies]
 tempfile = "3"
 [target."cfg(any(target_os = \"macos\", windows, target_os = \"linux\"))".dependencies]
-tauri-plugin-single-instance = { version = "2.0.0", features = ["deep-link"] }
+tauri-plugin-single-instance = "2.0.0"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,12 +1,3 @@
 fn main() {
-    let _ = dotenvy::dotenv();
-
-    // tell rust to recompile when .env changes
-    println!("cargo:rerun-if-env-changed=GH_APP_CLIENT_SECRET");
-
-    if let Ok(val) = std::env::var("GH_APP_CLIENT_SECRET") {
-        println!("cargo:rustc-env=GH_APP_CLIENT_SECRET={}", val);
-    }
-
     tauri_build::build()
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -10,7 +10,6 @@
     "opener:default",
     "dialog:default",
     "log:default",
-    "deep-link:default",
     "store:default"
   ]
 }

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -1,10 +1,10 @@
 use tauri::{command, AppHandle};
 
 use super::Result;
-use crate::services::auth;
+use crate::{models::DeviceFlowInfo, services::auth};
 
 #[command]
 #[specta::specta]
-pub async fn auth_github(app_handle: AppHandle) -> Result<()> {
-    Ok(auth::init_auth_flow(&app_handle)?)
+pub async fn auth_github(app_handle: AppHandle) -> Result<DeviceFlowInfo> {
+    Ok(auth::init_auth_flow(&app_handle).await?)
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -96,7 +96,7 @@ impl From<auth_svc::Error> for Error {
     fn from(err: auth_svc::Error) -> Self {
         log::error!("Auth error: {err}");
         match err {
-            auth_svc::Error::OpenUrl(_) => Error::Internal,
+            auth_svc::Error::Http(_) | auth_svc::Error::DeviceCodeRequest(_) => Error::Internal,
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,19 +16,16 @@ mod test_utils;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    let mut builder = tauri::Builder::default().plugin(tauri_plugin_deep_link::init());
+    let mut builder = tauri::Builder::default();
 
     #[cfg(desktop)]
     {
         builder = builder.plugin(tauri_plugin_single_instance::init(|_app, argv, _cwd| {
-          println!("a new app instance was opened with {argv:?} and the deep link event was already triggered");
-          // when defining deep link schemes at runtime, you must also check `argv` here
-          // 実行時に「deep link」スキーム（設定構成）を定義する場合は、ここで `argv` も確認する必要があります。
+            println!("a new app instance was opened with {argv:?}");
         }));
     }
 
     builder
-        .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(
             tauri_plugin_log::Builder::new()
@@ -42,19 +39,11 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
             log::info!("Application starting up - logging initialized");
             let app_dir = app.path().app_data_dir()?;
 
-            #[cfg(any(windows, target_os = "linux"))]
-            {
-                log::info!("Setting up deep link");
-                use tauri_plugin_deep_link::DeepLinkExt;
-                app.deep_link().register_all()?;
-            }
-
             std::fs::create_dir_all(&app_dir)
                 .map_err(|err| format!("Failed to create data directory: {}", err))?;
 
             Ok(())
         })
-        .plugin(tauri_plugin_opener::init())
         .invoke_handler(tauri::generate_handler![
             auth_github,
             get_change_id_from_sha,

--- a/src-tauri/src/models/auth.rs
+++ b/src-tauri/src/models/auth.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+#[derive(Debug, Serialize, Deserialize, Type, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceFlowInfo {
+    pub user_code: String,
+    pub verification_uri: String,
+}

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -1,7 +1,9 @@
+mod auth;
 mod entities;
 mod jj;
 mod pr;
 
+pub use auth::*;
 pub use entities::*;
 pub use jj::*;
 pub use pr::*;

--- a/src-tauri/src/services/auth.rs
+++ b/src-tauri/src/services/auth.rs
@@ -1,120 +1,160 @@
-use oauth2::{
-    basic::BasicClient, AuthUrl, AuthorizationCode, ClientId, ClientSecret, CsrfToken,
-    PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, TokenResponse, TokenUrl,
-};
-use obfstr::obfstring;
-use tauri::{AppHandle, Emitter, Url};
-use tauri_plugin_deep_link::DeepLinkExt;
+use crate::models::DeviceFlowInfo;
+use serde::Deserialize;
+use tauri::{AppHandle, Emitter};
 use tauri_plugin_opener::OpenerExt;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Failed to open URL: {0}")]
-    OpenUrl(String),
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("Device code request failed: {0}")]
+    DeviceCodeRequest(String),
 }
 
-const AUTH_URI: &str = "https://github.com/login/oauth/authorize";
-const TOKEN_URI: &str = "https://github.com/login/oauth/access_token";
+const DEVICE_CODE_URL: &str = "https://github.com/login/device/code";
+const TOKEN_URL: &str = "https://github.com/login/oauth/access_token";
 const CLIENT_ID: &str = "Iv23licutsPQwDRYefce";
-const REDIRECT_URL: &str = "revue://oauth";
 
-pub fn init_auth_flow(app_handle: &AppHandle) -> Result<()> {
-    log::info!("Initializing GitHub OAuth flow");
+#[derive(Debug, Deserialize)]
+struct DeviceCodeResponse {
+    device_code: String,
+    user_code: String,
+    verification_uri: String,
+    expires_in: u64,
+    interval: u64,
+}
 
-    let client = BasicClient::new(ClientId::new(CLIENT_ID.into()))
-        .set_client_secret(ClientSecret::new(
-            // NOTE: This only makes it harder to find client secret.
-            // However we cannot remove this because github api requires client secret
-            // even when using oauth2.0 pkce workflow even  though spec allow us to omit it.
-            obfstring!(std::env!("GH_APP_CLIENT_SECRET")),
-        ))
-        .set_token_uri(TokenUrl::new(TOKEN_URI.into()).expect("Should parse token uri"))
-        .set_auth_uri(AuthUrl::new(AUTH_URI.into()).expect("Should parse"))
-        .set_redirect_uri(RedirectUrl::new(REDIRECT_URL.into()).expect("Why would this ever fail"));
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    access_token: Option<String>,
+    error: Option<String>,
+}
 
-    let (code_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
-    let (auth_url, csrf_token) = client
-        .authorize_url(CsrfToken::new_random)
-        .set_pkce_challenge(code_challenge)
-        .url();
+pub async fn init_auth_flow(app_handle: &AppHandle) -> Result<DeviceFlowInfo> {
+    log::info!("Initializing GitHub Device Flow");
 
-    log::debug!("Generated auth URL: {}", auth_url);
+    let client = reqwest::Client::new();
 
-    app_handle
+    let response = client
+        .post(DEVICE_CODE_URL)
+        .header("Accept", "application/json")
+        .form(&[("client_id", CLIENT_ID), ("scope", "repo")])
+        .send()
+        .await?;
+
+    if !response.status().is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(Error::DeviceCodeRequest(body));
+    }
+
+    let device_response: DeviceCodeResponse = response.json().await?;
+
+    let info = DeviceFlowInfo {
+        user_code: device_response.user_code.clone(),
+        verification_uri: device_response.verification_uri.clone(),
+    };
+
+    let _ = app_handle
         .opener()
-        .open_url(auth_url, None::<String>)
-        .map_err(|err| Error::OpenUrl(err.to_string()))?;
+        .open_url(&device_response.verification_uri, None::<String>);
 
     let app_handle = app_handle.clone();
-    log::info!("Stating to listen for deep_link");
-    app_handle.clone().deep_link().on_open_url(move |event| {
-        let code_and_state = event
-            .urls()
-            .iter()
-            .filter_map(extract_code_and_state)
-            .next();
-        let Some((code, state)) = code_and_state else {
-            return;
-        };
-
-        if state != csrf_token {
-            log::error!("Got an invalid state");
-            return;
-        }
-
-        {
-            let pkce_verifier = PkceCodeVerifier::new(pkce_verifier.secret().into());
-            let client = client.clone();
-            let app_handle = app_handle.clone();
-            tauri::async_runtime::spawn(async move {
-                let http_client = oauth2::reqwest::Client::new();
-                let res = client
-                    .clone()
-                    .exchange_code(code)
-                    .set_pkce_verifier(pkce_verifier)
-                    .request_async(&http_client)
-                    .await;
-                match res {
-                    Ok(token_response) => {
-                        log::info!("Got github access token");
-                        let access_token = token_response.access_token();
-
-                        // Emit token to frontend for storage
-                        if let Err(err) = app_handle.emit("auth-token", access_token.secret()) {
-                            log::error!("Failed to emit auth token: {err}");
-                        }
-                    }
-                    Err(err) => {
-                        log::error!("Failed to get token: {:?}", err);
-                    }
-                }
-            });
-        }
+    tauri::async_runtime::spawn(async move {
+        poll_for_token(
+            &app_handle,
+            &client,
+            &device_response.device_code,
+            device_response.interval,
+            device_response.expires_in,
+        )
+        .await;
     });
 
-    Ok(())
+    Ok(info)
 }
 
-fn extract_code_and_state(url: &Url) -> Option<(AuthorizationCode, CsrfToken)> {
-    if url.scheme() != "revue" || url.host_str() != Some("oauth") {
-        log::warn!("Got unknown url: {url}");
-        return None;
+async fn poll_for_token(
+    app_handle: &AppHandle,
+    client: &reqwest::Client,
+    device_code: &str,
+    interval: u64,
+    expires_in: u64,
+) {
+    let started = std::time::Instant::now();
+    let mut interval_secs = interval;
+
+    loop {
+        if started.elapsed().as_secs() > expires_in {
+            log::error!("Device code expired");
+            let _ = app_handle.emit("auth-error", "Device code expired");
+            return;
+        }
+
+        tokio::time::sleep(std::time::Duration::from_secs(interval_secs)).await;
+
+        let response = client
+            .post(TOKEN_URL)
+            .header("Accept", "application/json")
+            .form(&[
+                ("client_id", CLIENT_ID),
+                ("device_code", device_code),
+                ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+            ])
+            .send()
+            .await;
+
+        let resp = match response {
+            Ok(resp) => resp,
+            Err(err) => {
+                log::error!("HTTP request failed during polling: {err}");
+                continue;
+            }
+        };
+
+        let token_resp = match resp.json::<TokenResponse>().await {
+            Ok(parsed) => parsed,
+            Err(err) => {
+                log::error!("Failed to parse token response: {err}");
+                continue;
+            }
+        };
+
+        if let Some(access_token) = token_resp.access_token {
+            log::info!("Got GitHub access token via device flow");
+            if let Err(err) = app_handle.emit("auth-token", &access_token) {
+                log::error!("Failed to emit auth token: {err}");
+            }
+            return;
+        }
+
+        match token_resp.error.as_deref() {
+            Some("authorization_pending") => continue,
+            Some("slow_down") => {
+                interval_secs += 5;
+                continue;
+            }
+            Some("expired_token") => {
+                log::error!("Device code expired");
+                let _ = app_handle.emit("auth-error", "Device code expired");
+                return;
+            }
+            Some("access_denied") => {
+                log::error!("User denied access");
+                let _ = app_handle.emit("auth-error", "Access denied");
+                return;
+            }
+            Some(err) => {
+                log::error!("Token polling error: {err}");
+                let _ = app_handle.emit("auth-error", err);
+                return;
+            }
+            None => {
+                log::error!("Unexpected response without access_token or error");
+                continue;
+            }
+        }
     }
-    let mut params = url.query_pairs();
-    let code = params.clone().find(|(key, _)| key == "code");
-    let Some((_, code)) = code else {
-        log::error!("Got callback url without code url: {url}");
-        return None;
-    };
-    let state = params.find(|(key, _)| key == "state");
-    let Some((_, state)) = state else {
-        log::error!("Got callback url without state. url: {url}");
-        return None;
-    };
-    Some((
-        AuthorizationCode::new(code.into()),
-        CsrfToken::new(state.into()),
-    ))
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -44,11 +44,6 @@
       "verbose": false,
       "visualizeDeps": false
     },
-    "deep-link": {
-      "desktop": {
-        "schemes": ["revue"]
-      }
-    },
     "store": null
   }
 }

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,24 +1,9 @@
 import { Link } from "@tanstack/react-router"
-import { Github } from "lucide-react"
-
-import { commands } from "@/bindings"
-import { Button } from "@/components/ui/button"
-import { useGithub } from "@/context/GithubContext"
-import { useRpcMutation } from "@/hooks/useRpcQuery"
-import { cn } from "@/lib/utils"
 
 import { AppCommands } from "./AppCommands"
+import { DeviceAuth } from "./DeviceAuth"
 
 export function AppHeader() {
-  const { isAuthenticated } = useGithub()
-
-  const authMutation = useRpcMutation({
-    mutationFn: () => commands.authGithub(),
-  })
-
-  const isNotAuthenticated = !isAuthenticated
-  const isAuthenticating = authMutation.isPending
-
   return (
     <header className="z-50 w-full shrink-0 border-b">
       <nav className="w-full flex h-14 items-center justify-between px-4">
@@ -27,22 +12,7 @@ export function AppHeader() {
           <div className="font-semibold text-lg">Revue</div>
         </Link>
         <AppCommands />
-
-        {isNotAuthenticated && (
-          <Button
-            onClick={() => authMutation.mutate(undefined)}
-            disabled={isAuthenticating}
-            className={cn(
-              "bg-[#24292f] text-white hover:bg-[#24292f]/90",
-              "gap-2 shadow-sm",
-            )}
-          >
-            <Github className="h-4 w-4" />
-            <span className="hidden sm:inline">
-              {isAuthenticating ? "Signing in..." : "Sign in with GitHub"}
-            </span>
-          </Button>
-        )}
+        <DeviceAuth />
       </nav>
     </header>
   )

--- a/src/components/DeviceAuth.tsx
+++ b/src/components/DeviceAuth.tsx
@@ -1,0 +1,110 @@
+import { ClipboardCopy, Github } from "lucide-react"
+import { useEffect, useState } from "react"
+
+import { commands } from "@/bindings"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { useGithub } from "@/context/GithubContext"
+import { useRpcMutation } from "@/hooks/useRpcQuery"
+import { cn } from "@/lib/utils"
+export function DeviceAuth() {
+  const { isAuthenticated } = useGithub()
+  const [deviceCode, setDeviceCode] = useState<{
+    userCode: string
+    verificationUri: string
+  } | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  const authMutation = useRpcMutation({
+    mutationFn: () => commands.authGithub(),
+    onSuccess: (data) => {
+      setDeviceCode(data)
+    },
+  })
+
+  const isNotAuthenticated = !isAuthenticated
+  const isAuthenticating = authMutation.isPending
+
+  // Close dialog when authentication completes
+  useEffect(() => {
+    if (isAuthenticated && deviceCode) {
+      setDeviceCode(null)
+    }
+  }, [isAuthenticated, deviceCode])
+
+  const handleCopy = async () => {
+    if (!deviceCode) return
+    await navigator.clipboard.writeText(deviceCode.userCode)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <>
+      {isNotAuthenticated && (
+        <Button
+          onClick={() => authMutation.mutate(undefined)}
+          disabled={isAuthenticating}
+          className={cn(
+            "bg-[#24292f] text-white hover:bg-[#24292f]/90",
+            "gap-2 shadow-sm",
+          )}
+        >
+          <Github className="h-4 w-4" />
+          <span className="hidden sm:inline">
+            {isAuthenticating ? "Signing in..." : "Sign in with GitHub"}
+          </span>
+        </Button>
+      )}
+
+      <Dialog
+        open={deviceCode !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeviceCode(null)
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Sign in to GitHub</DialogTitle>
+            <DialogDescription>
+              Enter this code on GitHub to authorize Revue
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex items-center justify-center gap-3 py-4">
+            <code className="rounded-md bg-muted px-4 py-3 text-2xl font-mono font-bold tracking-widest">
+              {deviceCode?.userCode}
+            </code>
+            <Button variant="outline" size="icon" onClick={handleCopy}>
+              <ClipboardCopy className="h-4 w-4" />
+              <span className="sr-only">{copied ? "Copied" : "Copy code"}</span>
+            </Button>
+          </div>
+          <p className="text-muted-foreground text-center text-sm">
+            A browser window should have opened automatically.
+            <br />
+            Waiting for authorization...
+          </p>
+          <DialogFooter showCloseButton>
+            <Button
+              variant="outline"
+              onClick={() => {
+                if (deviceCode) {
+                  window.open(deviceCode.verificationUri, "_blank")
+                }
+              }}
+            >
+              Open GitHub
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
Migrates GitHub authentication from the OAuth 2.0 PKCE flow with deep linking to the Device Flow (also known as Device Authorization Grant). This simplifies the authentication process by eliminating the need for custom URI schemes and deep link handling.

## Key Changes

### Backend (Rust)
- **Replaced OAuth2 library with direct HTTP requests**: Removed `oauth2` crate dependency and implemented Device Flow using `reqwest` for HTTP calls
- **Removed deep link infrastructure**: Eliminated `tauri-plugin-deep-link` dependency and all related deep link registration code
- **New authentication flow**:
  - `init_auth_flow()` now requests a device code from GitHub and returns `DeviceFlowInfo` containing the user code and verification URI
  - Added `poll_for_token()` async function that continuously polls GitHub's token endpoint until the user authorizes on their browser
  - Implements proper error handling for Device Flow specific errors (`authorization_pending`, `slow_down`, `expired_token`, `access_denied`)
- **Removed secrets handling**: Eliminated the obfuscated client secret from build process (no longer needed for Device Flow)
- **Updated command signature**: `auth_github` command now returns `DeviceFlowInfo` instead of `()`

### Frontend (React)
- **New Device Flow UI dialog**: Added a modal that displays the user code and verification URI
- **User code copy functionality**: Implemented clipboard copy button with visual feedback
- **Manual fallback link**: Added "Open GitHub" button in case the automatic browser opening fails
- **Auto-close on auth**: Dialog automatically closes when authentication completes

### Configuration & Dependencies
- Removed `dotenvy` and `obfstr` dependencies
- Removed deep link configuration from `tauri.conf.json`
- Removed `GH_APP_CLIENT_SECRET` environment variable from CI/CD workflows
- Updated `cspell.json` to remove obsolete terms

## Implementation Details
- Device Flow polling runs in a spawned async task that emits `auth-token` event on success or `auth-error` event on failure
- Implements exponential backoff for `slow_down` errors (increases interval by 5 seconds)
- Respects device code expiration time and stops polling after expiration
- All HTTP requests include proper `Accept: application/json` headers

https://claude.ai/code/session_0185n7r7F7L5Bvpjw8gBv7aW