### PR TITLE
Add Jujutsu (jj) installation to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
 
+      - name: Install Jujutsu (jj)
+        run: |
+          JJ_VERSION="0.38.0"
+          curl -fsSL "https://github.com/jj-vcs/jj/releases/download/v${JJ_VERSION}/jj-v${JJ_VERSION}-x86_64-unknown-linux-musl.tar.gz" -o /tmp/jj.tar.gz
+          mkdir -p /tmp/jj-extract
+          tar xzf /tmp/jj.tar.gz -C /tmp/jj-extract
+          sudo install /tmp/jj-extract/jj /usr/local/bin/jj
+          jj --version
+
       - run: cargo fmt --check --manifest-path src-tauri/Cargo.toml
       - run: cargo test --workspace
 


### PR DESCRIPTION
## Summary
This PR adds Jujutsu (jj) version control system installation to the CI workflow, enabling the use of jj commands in the continuous integration pipeline.

## Key Changes
- Added a new CI step to install Jujutsu v0.38.0 from the official GitHub releases
- Downloads the x86_64 Linux musl binary and installs it to `/usr/local/bin/jj`
- Includes version verification step to confirm successful installation

## Implementation Details
- Uses curl to download the pre-built binary tarball from the jj-vcs/jj GitHub repository
- Extracts the tarball to a temporary directory before installing to system PATH
- Runs `jj --version` to verify the installation was successful
- Positioned early in the workflow before cargo commands to ensure jj is available for subsequent steps

https://claude.ai/code/session_012UtDxv5RkHYPN2BWwtppow