### PR TITLE
Refactor line mode cursor tracking to use line identity instead of indices

### DIFF
--- a/src/components/Diff/DualDiff.tsx
+++ b/src/components/Diff/DualDiff.tsx
@@ -36,7 +36,7 @@ export function DualDiff({
       setActivePanel((prev) => {
         const next = prev === "remaining" ? "reviewed" : "remaining"
         lineMode?.setState({
-          cursorIndex: 0,
+          cursor: { line: 0, side: "RIGHT" },
           selection: { isSelecting: false },
         })
         return next
@@ -115,11 +115,7 @@ function DualPanel({
             <div className="px-3 py-0.5 font-mono text-xs text-muted-foreground bg-muted/30 border-y border-border/50 select-none">
               {element.hunk.header}
             </div>
-            <UnifiedHunkLines
-              hunk={element.hunk}
-              elementIndex={originalIndex}
-              lineCursor={lineCursor}
-            />
+            <UnifiedHunkLines hunk={element.hunk} lineCursor={lineCursor} />
           </div>
         ))
       )}

--- a/src/components/Diff/FileDiffItem.tsx
+++ b/src/components/Diff/FileDiffItem.tsx
@@ -81,7 +81,7 @@ export function FileDiffItem({
     setIsOpen(true)
     setSuppressNavigation(true)
     setLineModeState({
-      cursorIndex: 0,
+      cursor: { line: 0, side: "RIGHT" },
       selection: { isSelecting: false },
     })
   }, [setSuppressNavigation])


### PR DESCRIPTION
## Summary

This PR refactors the line mode cursor and selection tracking system to use semantic line identities (`LineIdentity`) instead of global array indices. This makes the cursor position more robust to DOM changes and improves code clarity.

## Key Changes

- **Introduced `LineIdentity` type**: Replaces index-based tracking with `{ line: number, side: "LEFT" | "RIGHT" }` to uniquely identify lines across view modes
- **Added helper functions**:
  - `lineKey()`: Converts `LineIdentity` to a string key for comparison
  - `lineIdentityForDiffLine()`: Extracts identity from a `DiffLine`
  - `lineIdentityForPairedLine()`: Extracts identity from a paired line in split view
  - `computeSelectedKeys()`: Computes selected line keys from anchor and cursor identities
  - Navigation helpers: `moveBy()`, `moveToBoundary()`, `moveToAdjacentHunk()`, `clampCursor()`

- **Updated `LineModeState`**: Changed from `cursorIndex: number` to `cursor: LineIdentity`
- **Updated `SelectionState`**: Changed from `anchorIndex: number` to `anchor: LineIdentity`
- **Refactored `LineCursorProps`**: 
  - Removed `elementRowOffsets` and `selectionRange`
  - Added `cursorKey: string` and `selectedKeys: ReadonlySet<string>`

- **Replaced `resolveGlobalRangeToRegion()` with `resolveSelectionToRegion()`**: Now takes two `LineIdentity` parameters instead of start/end indices, using a state machine approach for cleaner logic

- **Removed index-based navigation**: Replaced global index calculations with on-demand identity collection and lookup, eliminating the need for `totalRows` memoization

- **Updated DOM attributes**: Changed from `data-nav-index` to `data-line-id` for cursor scrolling

- **Updated all diff view components** (`UnifiedDiff`, `SplitDiff`): Simplified line rendering to use identity-based cursor/selection checks instead of index comparisons

## Implementation Details

- Navigation now dynamically collects valid line identities from elements rather than pre-computing offsets
- Selection range computation uses a state machine ("before" → "in" → "done") for clearer logic
- The refactoring maintains all existing keyboard shortcuts and behavior while improving maintainability
- Tests updated to use the new `LineIdentity`-based API with helper function `identityAt()`

https://claude.ai/code/session_01Ua6GP5LM2EsEZq62zR3cNS