### PR TITLE
Display inline review comments directly in diff view

### DIFF
--- a/src/components/Diff/FileDiffItem.tsx
+++ b/src/components/Diff/FileDiffItem.tsx
@@ -58,10 +58,15 @@ export function FileDiffItem({
   file,
   commentContext,
   InlineCommentForm,
+  getInlineThreads,
 }: {
   file: FileEntry
   commentContext?: CommentContext
   InlineCommentForm?: React.FC<InlineCommentFormProps>
+  getInlineThreads?: (
+    line: number,
+    side: "LEFT" | "RIGHT",
+  ) => React.ReactNode | null
 }) {
   const { localDir, commitSha, changeId } = useDiffContext()
   const { softFocusPaneItem } = usePaneManager()
@@ -310,6 +315,7 @@ export function FileDiffItem({
               }
               commentContext={commentContext}
               InlineCommentForm={InlineCommentForm}
+              getInlineThreads={getInlineThreads}
               lineMode={{
                 state: lineModeState,
                 setState: setLineModeState,
@@ -328,12 +334,17 @@ function LazyFileDiff({
   oldPath,
   commentContext,
   InlineCommentForm,
+  getInlineThreads,
   lineMode,
 }: {
   filePath: string
   oldPath?: string
   commentContext?: CommentContext
   InlineCommentForm?: React.FC<InlineCommentFormProps>
+  getInlineThreads?: (
+    line: number,
+    side: "LEFT" | "RIGHT",
+  ) => React.ReactNode | null
   lineMode: LineModeControl
 }) {
   const { localDir, commitSha, changeId, diffViewMode } = useDiffContext()
@@ -501,6 +512,7 @@ function LazyFileDiff({
     onLineDragEnter: handleLineDragEnter,
     onLineDragEnd: handleLineDragEnd,
     commentForm,
+    getInlineThreads,
     lineCursor,
   }
 

--- a/src/components/Diff/SplitDiff.tsx
+++ b/src/components/Diff/SplitDiff.tsx
@@ -24,6 +24,10 @@ export type DiffViewProps = {
   onLineDragEnter?: (line: number, side: "LEFT" | "RIGHT") => void
   onLineDragEnd?: () => void
   commentForm?: React.ReactNode
+  getInlineThreads?: (
+    line: number,
+    side: "LEFT" | "RIGHT",
+  ) => React.ReactNode | null
   lineCursor?: LineCursorProps
 }
 
@@ -62,6 +66,10 @@ type HunkLinesProps = {
   onLineDragEnter?: (line: number, side: "LEFT" | "RIGHT") => void
   onLineDragEnd?: () => void
   commentForm?: React.ReactNode
+  getInlineThreads?: (
+    line: number,
+    side: "LEFT" | "RIGHT",
+  ) => React.ReactNode | null
   lineCursor?: LineCursorProps
 }
 
@@ -73,6 +81,7 @@ function SplitHunkLines({
   onLineDragEnter,
   onLineDragEnd,
   commentForm,
+  getInlineThreads,
   lineCursor,
 }: HunkLinesProps) {
   const pairedLines = pairLinesForSplitView(hunk.lines)
@@ -139,6 +148,16 @@ function SplitHunkLines({
             }
           : undefined
 
+        const leftThreads =
+          getInlineThreads && pair.left?.oldLineno != null
+            ? getInlineThreads(pair.left.oldLineno, "LEFT")
+            : null
+        const rightThreads =
+          getInlineThreads && pair.right?.newLineno != null
+            ? getInlineThreads(pair.right.newLineno, "RIGHT")
+            : null
+        const inlineThreads = leftThreads || rightThreads
+
         return (
           <Fragment key={key(pair)}>
             <SplitLineRow
@@ -153,6 +172,11 @@ function SplitHunkLines({
             {isCommentTarget(pair) && commentForm && (
               <div className="border-y border-blue-300 dark:border-blue-700 bg-muted/30">
                 {commentForm}
+              </div>
+            )}
+            {inlineThreads && (
+              <div className="border-y border-blue-300/50 dark:border-blue-700/50 bg-muted/20 py-1">
+                {inlineThreads}
               </div>
             )}
           </Fragment>

--- a/src/components/Diff/UnifiedDiff.tsx
+++ b/src/components/Diff/UnifiedDiff.tsx
@@ -49,6 +49,10 @@ type HunkLinesProps = {
   onLineDragEnter?: (line: number, side: "LEFT" | "RIGHT") => void
   onLineDragEnd?: () => void
   commentForm?: React.ReactNode
+  getInlineThreads?: (
+    line: number,
+    side: "LEFT" | "RIGHT",
+  ) => React.ReactNode | null
   lineCursor?: LineCursorProps
 }
 
@@ -60,6 +64,7 @@ export function UnifiedHunkLines({
   onLineDragEnter,
   onLineDragEnd,
   commentForm,
+  getInlineThreads,
   lineCursor,
 }: HunkLinesProps) {
   const isCommentTarget = (line: DiffLine): boolean => {
@@ -118,6 +123,17 @@ export function UnifiedHunkLines({
             }
           : undefined
 
+        const lineNumber =
+          line.lineType === "deletion"
+            ? line.oldLineno
+            : (line.newLineno ?? line.oldLineno)
+        const side: "LEFT" | "RIGHT" =
+          line.lineType === "deletion" ? "LEFT" : "RIGHT"
+        const inlineThreads =
+          getInlineThreads && lineNumber != null
+            ? getInlineThreads(lineNumber, side)
+            : null
+
         return (
           <Fragment key={key(line)}>
             <DiffLineComponent
@@ -131,6 +147,11 @@ export function UnifiedHunkLines({
             {isCommentTarget(line) && commentForm && (
               <div className="border-y border-blue-300 dark:border-blue-700 bg-muted/30">
                 {commentForm}
+              </div>
+            )}
+            {inlineThreads && (
+              <div className="border-y border-blue-300/50 dark:border-blue-700/50 bg-muted/20 py-1">
+                {inlineThreads}
               </div>
             )}
           </Fragment>

--- a/src/routes/pulls.$owner.$repo.$number/-components/FilesTab.tsx
+++ b/src/routes/pulls.$owner.$repo.$number/-components/FilesTab.tsx
@@ -159,6 +159,7 @@ export function FilesTab({ localDir, owner, repo, prNumber }: FilesTabProps) {
                       owner={owner}
                       repo={repo}
                       prNumber={prNumber}
+                      remoteUrls={remoteUrls}
                     />
                   </CommitDiffSection>
                 </>

--- a/src/routes/pulls.$owner.$repo.$number/-components/InlineCommentThread.tsx
+++ b/src/routes/pulls.$owner.$repo.$number/-components/InlineCommentThread.tsx
@@ -1,0 +1,114 @@
+import { Reply } from "lucide-react"
+import { useState } from "react"
+
+import { InlineCommentForm } from "@/components/InlineCommentForm"
+import { MarkdownContent } from "@/components/MarkdownContent"
+import { Button } from "@/components/ui/button"
+import { formatRelativeTime } from "@/lib/timeUtils"
+
+import { useCreateReviewComment } from "../-hooks/useCreateReviewComment"
+import {
+  type ReviewComment,
+  type ThreadedComment,
+} from "../-hooks/useReviewComments"
+
+function CommentAvatar({ user }: { user: ReviewComment["user"] }) {
+  return (
+    <div className="w-5 h-5 rounded-full bg-muted flex items-center justify-center text-[10px] font-medium shrink-0 overflow-hidden">
+      {user?.avatar_url ? (
+        <img
+          src={user.avatar_url}
+          alt={user.login}
+          className="w-full h-full object-cover"
+        />
+      ) : (
+        user?.login[0].toUpperCase() || "?"
+      )}
+    </div>
+  )
+}
+
+function CommentBody({ comment }: { comment: ReviewComment }) {
+  return (
+    <div>
+      <div className="flex items-center gap-1.5 mb-1">
+        <CommentAvatar user={comment.user} />
+        <span className="font-semibold text-xs">{comment.user?.login}</span>
+        <span className="text-[10px] text-muted-foreground">
+          {formatRelativeTime(comment.created_at)}
+        </span>
+      </div>
+      <div className="pl-6.5 text-xs">
+        <MarkdownContent>{comment.body}</MarkdownContent>
+      </div>
+    </div>
+  )
+}
+
+export function InlineCommentThread({
+  thread,
+  owner,
+  repo,
+  prNumber,
+}: {
+  thread: ThreadedComment
+  owner: string
+  repo: string
+  prNumber: number
+}) {
+  const [isReplying, setIsReplying] = useState(false)
+  const createCommentMutation = useCreateReviewComment()
+
+  const handleReply = (body: string) => {
+    createCommentMutation.mutateAsync({
+      type: "reply",
+      owner,
+      repo,
+      pullNumber: prNumber,
+      body,
+      inReplyTo: thread.root.id,
+      commitId: thread.root.original_commit_id,
+      path: thread.root.path,
+    })
+    setIsReplying(false)
+  }
+
+  return (
+    <div className="rounded border bg-card mx-2 my-1">
+      {/* Root comment */}
+      <div className="p-3">
+        <CommentBody comment={thread.root} />
+      </div>
+
+      {/* Replies */}
+      {thread.replies.map((reply) => (
+        <div key={reply.id} className="border-t p-3">
+          <CommentBody comment={reply} />
+        </div>
+      ))}
+
+      {/* Reply section */}
+      {isReplying ? (
+        <div className="border-t">
+          <InlineCommentForm
+            onSubmit={handleReply}
+            onCancel={() => setIsReplying(false)}
+            placeholder="Write a reply..."
+          />
+        </div>
+      ) : (
+        <div className="border-t px-2 py-1">
+          <Button
+            variant="ghost"
+            size="xs"
+            onClick={() => setIsReplying(true)}
+            className="w-full text-muted-foreground"
+          >
+            <Reply className="w-3 h-3" />
+            Reply
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/routes/pulls.$owner.$repo.$number/-components/PRDiffContent.tsx
+++ b/src/routes/pulls.$owner.$repo.$number/-components/PRDiffContent.tsx
@@ -1,10 +1,18 @@
-import { useEffect } from "react"
+import { useCallback, useEffect, useMemo } from "react"
 
 import { FileDiffItem, Header, useDiffContext } from "@/components/Diff"
 import { InlineCommentForm } from "@/components/InlineCommentForm"
 import { usePaneContext } from "@/components/Pane"
+import { useShaToChangeId } from "@/context/ShaToChangeIdContext"
 
 import { useCreateReviewComment } from "../-hooks/useCreateReviewComment"
+import {
+  buildCommentThreads,
+  type ReviewComment,
+  type ThreadedComment,
+  useReviewComments,
+} from "../-hooks/useReviewComments"
+import { InlineCommentThread } from "./InlineCommentThread"
 import { focusFileComment } from "./ReviewCommentsSidebar"
 
 function useScrollCommentsOnFocus() {
@@ -23,14 +31,93 @@ export function PRDiffContent({
   owner,
   repo,
   prNumber,
+  remoteUrls,
 }: {
   owner: string
   repo: string
   prNumber: number
+  remoteUrls: string[]
 }) {
-  const { files, changeId } = useDiffContext()
+  const { files, changeId, commitSha, localDir } = useDiffContext()
   const createCommentMutation = useCreateReviewComment()
   useScrollCommentsOnFocus()
+
+  const { data: allComments } = useReviewComments(owner, repo, prNumber)
+  const { getChangeId } = useShaToChangeId()
+
+  // Filter comments for the current commit
+  const commentsByFile = useMemo(() => {
+    const map = new Map<string, ReviewComment[]>()
+    if (!allComments) return map
+
+    for (const comment of allComments) {
+      const commentChangeId = getChangeId(
+        comment.original_commit_id,
+        localDir,
+        remoteUrls,
+      )
+      const matches =
+        commentChangeId != null
+          ? commentChangeId === changeId
+          : comment.original_commit_id === commitSha
+
+      if (matches) {
+        const existing = map.get(comment.path) ?? []
+        existing.push(comment)
+        map.set(comment.path, existing)
+      }
+    }
+
+    return map
+  }, [allComments, getChangeId, localDir, remoteUrls, changeId, commitSha])
+
+  const inlineThreadNodes = useMemo(() => {
+    const result = new Map<string, Map<string, React.ReactNode>>()
+
+    for (const [filePath, fileComments] of commentsByFile) {
+      const threads = buildCommentThreads(fileComments)
+      if (threads.length === 0) continue
+
+      const nodesByKey = new Map<string, React.ReactNode>()
+      // Group threads by line:side
+      const threadsByKey = new Map<string, ThreadedComment[]>()
+      for (const thread of threads) {
+        const line = thread.root.line ?? thread.root.original_line
+        if (line == null) continue
+        const key = `${line}:${thread.root.side}`
+        const existing = threadsByKey.get(key) ?? []
+        existing.push(thread)
+        threadsByKey.set(key, existing)
+      }
+
+      for (const [key, keyThreads] of threadsByKey) {
+        nodesByKey.set(
+          key,
+          <InlineThreadGroup
+            threads={keyThreads}
+            owner={owner}
+            repo={repo}
+            prNumber={prNumber}
+          />,
+        )
+      }
+
+      result.set(filePath, nodesByKey)
+    }
+
+    return result
+  }, [commentsByFile, owner, repo, prNumber])
+
+  const makeGetInlineThreads = useCallback(
+    (filePath: string) => {
+      const nodesByKey = inlineThreadNodes.get(filePath)
+      if (!nodesByKey) return undefined
+
+      return (line: number, side: "LEFT" | "RIGHT") =>
+        nodesByKey.get(`${line}:${side}`) ?? null
+    },
+    [inlineThreadNodes],
+  )
 
   const handleCreateComment = async (params: {
     body: string
@@ -64,15 +151,45 @@ export function PRDiffContent({
     <div className="space-y-2">
       <Header />
       <div className="space-y-3">
-        {files.map((file) => (
-          <FileDiffItem
-            key={`${changeId}-${file.newPath || file.oldPath}`}
-            file={file}
-            commentContext={commentContext}
-            InlineCommentForm={InlineCommentForm}
-          />
-        ))}
+        {files.map((file) => {
+          const filePath = file.newPath || file.oldPath || ""
+          return (
+            <FileDiffItem
+              key={`${changeId}-${filePath}`}
+              file={file}
+              commentContext={commentContext}
+              InlineCommentForm={InlineCommentForm}
+              getInlineThreads={makeGetInlineThreads(filePath)}
+            />
+          )
+        })}
       </div>
     </div>
+  )
+}
+
+function InlineThreadGroup({
+  threads,
+  owner,
+  repo,
+  prNumber,
+}: {
+  threads: ThreadedComment[]
+  owner: string
+  repo: string
+  prNumber: number
+}) {
+  return (
+    <>
+      {threads.map((thread) => (
+        <InlineCommentThread
+          key={thread.root.id}
+          thread={thread}
+          owner={owner}
+          repo={repo}
+          prNumber={prNumber}
+        />
+      ))}
+    </>
   )
 }


### PR DESCRIPTION
## Summary
This PR adds the ability to display review comments and their reply threads directly inline within the diff view, rather than only showing them in the sidebar. Comments are now rendered at their respective line locations in both split and unified diff views.

## Key Changes

- **New `InlineCommentThread` component**: Created a dedicated component to render individual comment threads with replies, avatars, timestamps, and reply functionality
- **Comment thread building utility**: Extracted `buildCommentThreads()` function to `useReviewComments.ts` for reusable comment-to-thread conversion logic, used by both sidebar and inline views
- **Inline thread rendering in diff**: 
  - Added `getInlineThreads` callback prop to `FileDiffItem`, `SplitDiff`, and `UnifiedDiff` components
  - Threads are rendered below their corresponding diff lines with visual styling (border and background)
- **Comment filtering by commit**: Implemented logic in `PRDiffContent` to filter review comments for the current commit using `ShaToChangeIdContext`, supporting both local and remote repository contexts
- **Thread organization**: Comments are grouped by file path and line number, with proper handling of both "LEFT" (deletion) and "RIGHT" (addition) sides in split view
- **Updated `ReviewCommentsSidebar`**: Refactored to use the new `buildCommentThreads()` utility function, reducing code duplication

## Implementation Details

- Comments are matched to the current commit by comparing either the `changeId` (for local repos) or `commitSha` (for remote repos)
- Inline threads are memoized to prevent unnecessary re-renders
- The `InlineThreadGroup` component handles rendering multiple threads at the same line location
- Reply functionality is integrated with the existing `useCreateReviewComment` mutation

https://claude.ai/code/session_01LjyVWeHoEvJuPktohh3EBp